### PR TITLE
Free tag via 'tab' or 'enter' key

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -356,6 +356,7 @@
                                     return true;
                                   } else {
                                     add_freetagging_tokens();
+                                    return true;
                                   }
                                 } else {
                                   $(this).val("");


### PR DESCRIPTION
We want to enable admins to freetag guests in setup > participation events by typing a string in a tokeninput form field and simply pressing `enter` or `tab` to save that value.
- After pressing `tab` or `enter`, populate the field with the users' string and move the cursor to the next field.

[#7]
