### PR TITLE
[#11] Restore 'onAdd' method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Full details and documentation can be found on the project page here:
 Custom WeSpire Functions
 ---------------------------------
 
-#### `onBeforeAdd`, `onAfterAdd`
+#### `onBeforeAdd`
 
-Both replace the default `onAdd` function, but run at either the beginning or end of the `add_token` method.
+Similar to the `onAdd` function, but runs at the very beginning of the `add_token` method.
 
 **Example Usage:**
 
@@ -25,9 +25,7 @@ Both replace the default `onAdd` function, but run at either the beginning or en
 ```coffee
 $(‘.js-some-input’).tokenInput AppRoutes.some_path({foo: bar}),
   onBeforeAdd: ( item ) ->
+    # When false is returned the entire `add_token` method is halted — the token is not added and the dropdown is not dismissed.
     if item.is_disabled
       return false
-  onAfterAdd: ( item ) ->
-    if item.is_super_cool
-      alert("Wowie, this is one cool item!")
 ```

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -65,7 +65,7 @@
     onResult: null,
     onCachedResult: null,
     onBeforeAdd: null,
-    onAfterAdd: null,
+    onAdd: null,
     onFreeTaggingAdd: null,
     onDelete: null,
     onReady: null,
@@ -650,7 +650,7 @@
                               // Add a token to the token list based on user input
                               function add_token (item) {
                                 var onBeforeAddCallback = $(input).data("settings").onBeforeAdd;
-                                var onAfterAddCallback = $(input).data("settings").onAfterAdd;
+                                var onAddCallback = $(input).data("settings").onAdd;
 
                                 // Execute the onBeforeAdd callback if defined
                                 if($.isFunction(onBeforeAddCallback)) {
@@ -697,9 +697,9 @@
                                 // Don't show the help dropdown, they've got the idea
                                 hide_dropdown();
 
-                                // Execute the onAfterAdd callback if defined
-                                if($.isFunction(onAfterAddCallback)) {
-                                    onAfterAddCallback.call(hiddenInput,item);
+                                // Execute the onAdd callback if defined
+                                if($.isFunction(onAddCallback)) {
+                                    onAddCallback.call(hiddenInput,item);
                                 }
                               }
 


### PR DESCRIPTION
Leaving the original method name in tact, and so `onBeforeAdd` is the only new, custom function.

[#11]
